### PR TITLE
Add missing parentheses in docs

### DIFF
--- a/docs/items-properties.md
+++ b/docs/items-properties.md
@@ -7,7 +7,7 @@
 Creating an item with label "test item"
 
 ```py
-item = py_wb.Item.create("test item")
+item = py_wb.Item().create("test item")
 ```
 
 ### Getting an item
@@ -15,7 +15,7 @@ item = py_wb.Item.create("test item")
 Fetching all information about the item with the ID "Q1":
 
 ```py
-item = py_wb.Item.get(entity_id="Q1")
+item = py_wb.Item().get(entity_id="Q1")
 ```
 
 Updating the information about a previously fetched item:
@@ -39,7 +39,7 @@ item.delete()
 Creating a property with label "location" and data type "GeoLocation"
 
 ```py
-prop = py_wb.Property.create("location", data_type="GeoLocation")
+prop = py_wb.Property().create("location", data_type="GeoLocation")
 ```
 
 _The default `data_type` is "StringValue"_
@@ -49,7 +49,7 @@ _The default `data_type` is "StringValue"_
 Fetching all information about the property with the ID "P1":
 
 ```py
-prop = py_wb.Property.get(entity_id="P1")
+prop = py_wb.Property().get(entity_id="P1")
 ```
 
 Updating the information about a previously fetched property:


### PR DESCRIPTION
Because `py_wb.Item` and `py_wb.Property` are functions.